### PR TITLE
drop nerdtree

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -83,7 +83,7 @@ let g:netrw_winsize = 25
 
 augroup ProjectDrawer
   autocmd!
-  autocmd VimEnter * :Vexplore
+  autocmd VimEnter * if expand("%") == "" | edit . | endif
 augroup END
 
 " }}}

--- a/vimrc
+++ b/vimrc
@@ -12,9 +12,6 @@ Plug 'neoclide/coc.nvim',
 
 Plug 'altercation/vim-colors-solarized'
 
-Plug 'preservim/nerdtree'
-Plug 'jistr/vim-nerdtree-tabs'
-
 Plug 'Raimondi/delimitMate'
 
 Plug 'SirVer/ultisnips'
@@ -78,10 +75,17 @@ let g:airline_theme='solarized'
 let g:airline_solarized_bg='dark'
 " }}}
 
-" NERDTree {{{
-map <C-e> :NERDTreeMirrorToggle<CR>
+" built-in file explorer {{{
+let g:netrw_liststyle = 3
+let g:netrw_browse_split = 4
+let g:netrw_altv = 1
+let g:netrw_winsize = 25
 
-let NERDTreeIgnore = ['\.pyc$']
+augroup ProjectDrawer
+  autocmd!
+  autocmd VimEnter * :Vexplore
+augroup END
+
 " }}}
 
 " Dispatch {{{


### PR DESCRIPTION
- feat(vim): prefer built-in file explorer over NerdTree
- feat(vim): open file explorer only when no file is selected
