### PR TITLE
feat(vim): ignore too long lines in Python code

### DIFF
--- a/vim/ftplugin/python.vim
+++ b/vim/ftplugin/python.vim
@@ -9,3 +9,5 @@ if executable('black')
 endif
 
 let b:ale_fixers = ['autoimport']
+
+let g:ale_python_flake8_options = '--ignore=E501'


### PR DESCRIPTION
A code formatter will take care of too long lines.

Signed-off-by: Joris Clement <7713214+joclement@users.noreply.github.com>
