### PR TITLE
feat(vim): indent in markdown files by 2 instead of 4

### DIFF
--- a/vim/after/ftplugin/markdown.vim
+++ b/vim/after/ftplugin/markdown.vim
@@ -1,0 +1,3 @@
+setlocal shiftwidth=2
+setlocal softtabstop=2
+setlocal tabstop=2


### PR DESCRIPTION
Signed-off-by: Joris Clement <7713214+joclement@users.noreply.github.com>
