### PR TITLE
feat!: drop no longer needed plugin

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -28,8 +28,6 @@ antigen use oh-my-zsh
 
 antigen bundles <<EOBUNDLES
 
-voronkovich/gitignore.plugin.zsh
-
 # to go to parent dirs quickly
 Tarrasch/zsh-bd
 


### PR DESCRIPTION
I want to drop antigen because it has been updated the last time in
2019. Since I have now a general `gitignore` file, I no longer need such
gitignore boilerplate generation.
